### PR TITLE
Use `int` for `size` parameter of Guards exercise instead of `float`

### DIFF
--- a/GPU_Puzzlers_C++.ipynb
+++ b/GPU_Puzzlers_C++.ipynb
@@ -310,7 +310,7 @@
         "%%writefile guards_kernel.cu\n",
         "#include <cuda_runtime.h>\n",
         "\n",
-        "__global__ void Guards(float* A, float* C, float size) {\n",
+        "__global__ void Guards(float* A, float* C, int size) {\n",
         "  int i = threadIdx.x;\n",
         "\n",
         "  /// CODE HERE (approx 3 lines) ///\n",

--- a/GPU_puzzlers_exec/guards_runner.cu
+++ b/GPU_puzzlers_exec/guards_runner.cu
@@ -2,7 +2,7 @@
 #include <cassert>
 #include <cuda_runtime.h>
 
-extern __global__ void Guards(float* A, float* C, float size);
+extern __global__ void Guards(float* A, float* C, int size);
 
 void runKernel() {
     const int size = 3;


### PR DESCRIPTION
I am very new to CUDA programming, but I was surprised to see the `size` parameter (which is the array size) having a type of `float`. Is there any reason to not make this an int instead?